### PR TITLE
fix rest-client version in gemspec

### DIFF
--- a/source/lib/vagrant-conoha/version.rb
+++ b/source/lib/vagrant-conoha/version.rb
@@ -4,7 +4,7 @@ module VagrantPlugins
     # Stable versions must respect the pattern given
     # by VagrantPlugins::ConoHa::VERSION_PATTERN
     #
-    VERSION = '0.1.2'
+    VERSION = '0.1.3'
 
     #
     # Stable version must respect the naming convention 'x.y.z'

--- a/source/vagrant-conoha.gemspec
+++ b/source/vagrant-conoha.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
   gem.license       = 'MIT'
 
   gem.add_dependency 'json', '~> 1.8.3'
-  gem.add_dependency 'rest-client', '~> 1.8.0'
+  gem.add_dependency 'rest-client', '~> 1.6.0'
   gem.add_dependency 'terminal-table', '1.5.2'
   gem.add_dependency 'sshkey', '1.7.0'
   gem.add_dependency 'colorize', '0.7.7'


### PR DESCRIPTION
Fix bug that rest-client version is conflict.

``` shell
✗ vagrant plugin install  vagrant-conoha --plugin-version 0.1.2
Installing the 'vagrant-conoha --version '0.1.2'' plugin. This can take a few minutes...
The plugin(s) can't be installed due to the version conflicts below.
This means that the plugins depend on a library version that conflicts
with other plugins or Vagrant itself, creating an impossible situation
where Vagrant wouldn't be able to load the plugins.

You can fix the issue by either removing a conflicting plugin or
by contacting a plugin author to see if they can address the conflict.

Vagrant could not find compatible versions for gem "rest-client":
  In Gemfile:
    vagrant (= 1.7.4) ruby depends on
      rest-client (< 2.0, >= 1.6.0) ruby

    vagrant-conoha (= 0.1.2) ruby depends on
      rest-client (~> 1.8.0) ruby

    vagrant-share (>= 0) ruby depends on
      rest-client (~> 1.6.0) ruby
```
