### PR TITLE
Fix issue #5

### DIFF
--- a/source/Vagrantfile
+++ b/source/Vagrantfile
@@ -19,8 +19,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # CentOS系など/etc/sudoersにrequirettyが書いてある場合に必要になります。
   config.ssh.pty      = true
 
-  config.vm.provider :conoha do |conoha|
+  # ローカルのフォルダをホスト側のフォルダと同期することが出来ます。
+  # 必要に応じてコメントを外してください。
+  # https://www.vagrantup.com/docs/synced-folders/
+  #
+  # config.vm.synced_folder "./src", "/src"
 
+  config.vm.provider :conoha do |conoha|
     # IdentityEndpointを指定します
     # 東京以外のリージョンを利用する場合は変更して下さい。
     conoha.openstack_auth_url = 'https://identity.tyo1.conoha.io/v2.0'
@@ -95,6 +100,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # 指定が無い場合は、Vagrantが新しい鍵ペアを自動作成します。
     #
     # conoha.keypair_name       = "my-keypair"
+
+    # Vagrantのsynced_folder を使う場合の同期方法を指定します。
+    # 設定できるのは"rsync"と"none"です。特に変更する必要はありません。
+    conoha.sync_method = "rsync"
 
     # スタートアップスクリプトを指定します。
     # cloud-config形式、シェルスクリプト形式、どちらでも記述できます。

--- a/source/lib/vagrant-conoha/version.rb
+++ b/source/lib/vagrant-conoha/version.rb
@@ -4,7 +4,7 @@ module VagrantPlugins
     # Stable versions must respect the pattern given
     # by VagrantPlugins::ConoHa::VERSION_PATTERN
     #
-    VERSION = '0.1.8'
+    VERSION = '0.1.9'
 
     #
     # Stable version must respect the naming convention 'x.y.z'


### PR DESCRIPTION
`vagrant up`の最後で例外が投げられ、.vagrant配下のファイルが更新される前にプログラムが終了していたのが原因。

Vagrantfileで`config.vm.provider.sync_method`が未定義の場合、Vagrantはこの設定のデフォルト値として"nfs"を使用するが、OpenStack Providerはこれに対応していないので、NFS Helperがエラーになる。

修正版ではVagrantfile内で"rsync"を明示するようにした。

```shell
#<Vagrant::Errors::NFSNoHostIP: No host IP was given to the Vagrant core NFS helper. This is
an internal error that should be reported as a bug.>
["/vagrant-conoha/source/lib/vagrant-conoha/action/abstract_action.rb:8:in `call'", "/var/lib/gems/2.3.0/bundler/gems/vagrant-d8c2b2e5abab/lib/vagrant/action/warden.rb:34:in `call'", "/var/lib/gems/2.3.0
/bundler/gems/vagrant-d8c2b2e5abab/lib/vagrant/action/builtin/config_validate.rb:25:in `call'", "/var/lib/gems/2.3.0/bundler/gems/vagrant-d8c2b2e5abab/lib/vagrant/action/warden.rb:34:in `call'", "/var/li
b/gems/2.3.0/bundler/gems/vagrant-d8c2b2e5abab/lib/vagrant/action/builtin/handle_box.rb:25:in `call'", "/var/lib/gems/2.3.0/bundler/gems/vagrant-d8c2b2e5abab/lib/vagrant/action/warden.rb:34:in `call'", "
/var/lib/gems/2.3.0/bundler/gems/vagrant-d8c2b2e5abab/lib/vagrant/action/builder.rb:116:in `call'", "/var/lib/gems/2.3.0/bundler/gems/vagrant-d8c2b2e5abab/lib/vagrant/action/runner.rb:66:in `block in run
'", "/var/lib/gems/2.3.0/bundler/gems/vagrant-d8c2b2e5abab/lib/vagrant/util/busy.rb:19:in `busy'", "/var/lib/gems/2.3.0/bundler/gems/vagrant-d8c2b2e5abab/lib/vagrant/action/runner.rb:66:in `run'", "/var/
lib/gems/2.3.0/bundler/gems/vagrant-d8c2b2e5abab/lib/vagrant/machine.rb:225:in `action_raw'", "/var/lib/gems/2.3.0/bundler/gems/vagrant-d8c2b2e5abab/lib/vagrant/machine.rb:200:in `block in action'", "/va
r/lib/gems/2.3.0/bundler/gems/vagrant-d8c2b2e5abab/lib/vagrant/environment.rb:567:in `lock'", "/var/lib/gems/2.3.0/bundler/gems/vagrant-d8c2b2e5abab/lib/vagrant/machine.rb:186:in `call'", "/var/lib/gems/
2.3.0/bundler/gems/vagrant-d8c2b2e5abab/lib/vagrant/machine.rb:186:in `action'", "/var/lib/gems/2.3.0/bundler/gems/vagrant-d8c2b2e5abab/lib/vagrant/batch_action.rb:82:in `block (2 levels) in run'"]
```